### PR TITLE
Add missing DeviceAttributes parameter to Update-UMSDevice

### DIFF
--- a/Docs/Reference/Update-UMSDevice.md
+++ b/Docs/Reference/Update-UMSDevice.md
@@ -16,7 +16,7 @@ Updates properties of a device.
 Update-UMSDevice [-Computername] <String> [[-TCPPort] <Int32>] [[-ApiVersion] <Int32>]
  [[-SecurityProtocol] <String[]>] [-WebSession] <Object> [-Id] <Int32> [[-Name] <String>] [[-Site] <String>]
  [[-Department] <String>] [[-CostCenter] <String>] [[-LastIP] <String>] [[-Comment] <String>]
- [[-AssetId] <String>] [[-InserviceDate] <String>] [[-SerialNumber] <String>] [-WhatIf] [-Confirm]
+ [[-AssetId] <String>] [[-InserviceDate] <String>] [[-SerialNumber] <String>] [[-DeviceAttributes] <Hashtable>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -59,6 +59,19 @@ $PSDefaultParameterValues += @{
 Message             Id
 -------             --
 Update successful.  58
+Update successful. 195
+```
+
+### Example 3
+
+Update the Value of the DeviceAttribute with the Identifier 'devattr1' on the device with ID 195 to 'NewValue' 
+and remove the Value of the DeviceAttribute with the Identifier 'devattr2' from the device with ID 195:
+
+```powershell
+Update-UMSDevice -Computername 'igelrmserver' -WebSession $WebSession -Id 195 -DeviceAttributes @{'devattr1' = 'NewName'; 'devattr2' = ''}
+
+Message             Id
+-------             --
 Update successful. 195
 ```
 
@@ -266,6 +279,21 @@ Device property site
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Benannt
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeviceAttributes
+Custom Device Attributes
+
+```yaml
+Type: Hashtable
 Parameter Sets: (All)
 Aliases:
 

--- a/Docs/Reference/Update-UMSDevice.md
+++ b/Docs/Reference/Update-UMSDevice.md
@@ -68,7 +68,7 @@ Update the Value of the DeviceAttribute with the Identifier 'devattr1' on the de
 and remove the Value of the DeviceAttribute with the Identifier 'devattr2' from the device with ID 195:
 
 ```powershell
-Update-UMSDevice -Computername 'igelrmserver' -WebSession $WebSession -Id 195 -DeviceAttributes @{'devattr1' = 'NewName'; 'devattr2' = ''}
+Update-UMSDevice -Computername 'igelrmserver' -WebSession $WebSession -Id 195 -DeviceAttributes @{'devattr1' = 'NewValue'; 'devattr2' = ''}
 
 Message             Id
 -------             --

--- a/PSIGEL/Public/Update-UMSDevice.ps1
+++ b/PSIGEL/Public/Update-UMSDevice.ps1
@@ -63,7 +63,11 @@
     [Parameter(ParameterSetName = 'Set')]
     [ValidateLength(18, 18)]
     [String]
-    $SerialNumber
+    $SerialNumber,
+
+    [Parameter(ParameterSetName = 'Set')]
+    [Hashtable]
+    $DeviceAttributes
   )
 
   Begin
@@ -113,6 +117,19 @@
         if ($PSBoundParameters.GetEnumerator().Where{ $_.Key -eq 'SerialNumber' })
         {
           $BodyHashTable.Add('serialNumber', $SerialNumber)
+        }
+        if ($PSBoundParameters.GetEnumerator().Where{ $_.Key -eq 'DeviceAttributes' })
+        {
+		      $DeviceAttributesArray = @()
+		      foreach ($DeviceAttribute in $DeviceAttributes.GetEnumerator()) {
+			      $DeviceAttributesArray += @(
+			        @{
+				        'identifier' = $DeviceAttribute.Key
+                'value' = $DeviceAttribute.Value
+			        }
+			      )
+	        }
+          $BodyHashTable.Add('deviceAttributes', $DeviceAttributesArray)
         }
         $Body = ConvertTo-Json $BodyHashTable
         $Params = @{

--- a/PSIGEL/Public/Update-UMSDevice.ps1
+++ b/PSIGEL/Public/Update-UMSDevice.ps1
@@ -120,15 +120,15 @@
         }
         if ($PSBoundParameters.GetEnumerator().Where{ $_.Key -eq 'DeviceAttributes' })
         {
-		      $DeviceAttributesArray = @()
-		      foreach ($DeviceAttribute in $DeviceAttributes.GetEnumerator()) {
-			      $DeviceAttributesArray += @(
-			        @{
-				        'identifier' = $DeviceAttribute.Key
-                'value' = $DeviceAttribute.Value
-			        }
-			      )
-	        }
+	  $DeviceAttributesArray = @()
+          foreach ($DeviceAttribute in $DeviceAttributes.GetEnumerator()) {
+            $DeviceAttributesArray += @(
+              @{
+               'identifier' = $DeviceAttribute.Key
+               'value' = $DeviceAttribute.Value
+              }
+            )
+          }
           $BodyHashTable.Add('deviceAttributes', $DeviceAttributesArray)
         }
         $Body = ConvertTo-Json $BodyHashTable


### PR DESCRIPTION
Hello again,

i have added the Parameter "DeviceAttributes" with the value of a Hashtable (consisting of `'deviceAttribute-Identifier' = 'deviceAttribute-NewValue'` Key-Value-Pairs) to Update-UMSDevice as i needed this function.

Giving an empty Value (e.g. `''` or `""`) with a vaild identifier removes the value/deviceattribute from the specified Device.
Giving a empty Hashtable (e.g. `@{}` )  or non-valid identifier or non-valid value (wrong type or not in range) is interpreted as a bad request by the API.

The associated Markdown-Docfile has been updated, the PSIGEL-Help.xml has not been updated by me (didnt want to break anything there).

![grafik](https://user-images.githubusercontent.com/29387023/173064775-eaeffe79-b2ca-488d-8dea-e3f3079c8fdf.png)
