### PR TITLE
patch wrong cast of deviceattributes

### DIFF
--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -168,11 +168,11 @@
                 }
                 string
                 {
-                  $AttributeProperties.Add('Value', [Single]$DeviceAttribute.value)
+                  $AttributeProperties.Add('Value', [String]$DeviceAttribute.value)
                 }
                 number
                 {
-                  $AttributeProperties.Add('Value', [String]$DeviceAttribute.value)
+                  $AttributeProperties.Add('Value', [Single]$DeviceAttribute.value)
                 }
               }
               $AttributePropertiesObject = New-Object PSObject -Property $AttributeProperties


### PR DESCRIPTION
There was a mixup in the casting of device attributes.
String values would be casted as Single / Integer and number values would be casted to String which - depending on the input values - resulted in a casting error.